### PR TITLE
chore: Add build check workflow and optimize components

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,31 @@
+name: Build Check
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint check
+        run: npm run lint
+
+      - name: Build project
+        run: npm run build

--- a/app/components/csr/useWindowWidth.tsx
+++ b/app/components/csr/useWindowWidth.tsx
@@ -3,9 +3,11 @@
 import { useState, useEffect } from 'react';
 
 export default function useWindowWidth() {
-  const [width, setWidth] = useState<number>(window.innerWidth);
+  const [width, setWidth] = useState<number>(0);
 
   useEffect(() => {
+    setWidth(window.innerWidth);
+
     const handleResize = () => setWidth(window.innerWidth);
 
     window.addEventListener('resize', handleResize);

--- a/app/components/home/Partners.tsx
+++ b/app/components/home/Partners.tsx
@@ -1,4 +1,5 @@
 import { Container } from '../ui/container';
+import Image from 'next/image';
 
 export function Partners() {
   const partners = [
@@ -19,9 +20,11 @@ export function Partners() {
               key={partner.name}
               className="bg-green-700 p-6 rounded-lg flex items-center justify-center"
             >
-              <img
+              <Image
                 src={partner.logo}
                 alt={partner.name}
+                width={100}
+                height={100}
                 className="h-12 w-auto"
               />
             </div>

--- a/app/components/home/PythonFoundation.tsx
+++ b/app/components/home/PythonFoundation.tsx
@@ -1,4 +1,5 @@
 import { Container } from '../ui/container';
+import Image from 'next/image';
 
 export function PythonFoundation() {
   return (
@@ -8,9 +9,11 @@ export function PythonFoundation() {
           <h2 className="text-3xl font-bold text-white mb-8">Recognized by</h2>
           <div className="flex justify-center items-center">
             <div className="bg-white p-8 rounded-lg">
-              <img
+              <Image
                 src="/python-logo.svg"
                 alt="Python Software Foundation"
+                width={100}
+                height={100}
                 className="h-16 w-auto"
               />
               <p className="mt-4 text-green-900 font-medium">

--- a/app/components/navs/public/Navbar.tsx
+++ b/app/components/navs/public/Navbar.tsx
@@ -18,7 +18,7 @@ export default function Navbar() {
           height={44.72}
         />
         <div className="flex justify-between items-center w-full">
-          {width < 1024 ? <MobileView /> : <DesktopView />}
+          {width > 0 && (width < 1024 ? <MobileView /> : <DesktopView />)}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
**Error:**
```
./app/components/home/Partners.tsx
22:15  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./app/components/home/PythonFoundation.tsx
11:15  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
 ✓ Linting and checking validity of types
 ✓ Collecting page data
   Generating static pages (0/5)  [    ]ReferenceError: window is not defined
    at /Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13082
    at H (/Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13110)
    at nj (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:46251)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47571)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:61546)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nD (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:66680)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64853)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538) {
  digest: '1185459714'
}
ReferenceError: window is not defined
    at /Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13082
    at H (/Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13110)
    at nj (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:46251)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47571)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:61546)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nD (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:66680)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64853)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538) {
  digest: '1185459714'
}

Error occurred prerendering page "/_not-found". Read more: https://nextjs.org/docs/messages/prerender-error

ReferenceError: window is not defined
    at /Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13082
    at H (/Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13110)
    at nj (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:46251)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47571)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:61546)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nD (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:66680)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64853)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)

Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error

ReferenceError: window is not defined
    at /Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13082
    at H (/Users/arjsarmiento/Projects/durianpy/durianpy.org/.next/server/chunks/575.js:1:13110)
    at nj (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:46251)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47571)
    at nM (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:61546)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64546)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
    at nD (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:66680)
    at nN (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:64853)
    at nB (/Users/arjsarmiento/Projects/durianpy/durianpy.org/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:67538)
 ✓ Generating static pages (5/5)

> Export encountered errors on following paths:
        /_not-found/page: /_not-found
        /page: /
```


**Root Cause:**
The error window is not defined is coming from your useWindowWidth hook which is being used during server-side rendering. This happens because window is only available in the browser, not during server-side rendering or static generation.